### PR TITLE
Yama

### DIFF
--- a/encourage/pages/calendar.vue
+++ b/encourage/pages/calendar.vue
@@ -4,6 +4,9 @@
       <v-btn outlined nuxt to="/">
         <v-icon> mdi-chevron-left </v-icon>Top Page
       </v-btn>
+      <v-btn @click="addEvent">
+        add Event
+      </v-btn>
       <v-sheet height="64">
         <v-toolbar flat>
           <v-btn outlined class="mr-4" color="grey darken-2" @click="setToday">
@@ -185,10 +188,30 @@ export default {
           timed: !allDay,
         })
       }
+      
+      events.push({
+        name: '就活講座',
+        start: new Date(2022, 6-1, 25, 13, 30, 30),
+        end: new Date(2022, 6-1, 25, 15, 50, 50),
+        color: 'blue',
+        timed: true,
+      })
       this.events = events
+      console.log(this.events)
     },
     rnd(a, b) {
       return Math.floor((b - a + 1) * Math.random()) + a
+    },
+    addEvent() {
+      const events = this.events
+      events.push({
+        name: '就活講座',
+        start: new Date(2022, 6-1, 25, 13),
+        end: new Date(2022, 6-1, 25, 15),
+        color: 'red',
+        timed: true,
+      })
+      this.events = events
     },
   },
 }

--- a/encourage/pages/calendar.vue
+++ b/encourage/pages/calendar.vue
@@ -6,7 +6,6 @@
           <v-btn outlined nuxt to="/">
             <v-icon> mdi-chevron-left </v-icon>Top Page
           </v-btn>
-          <!-- <v-btn @click="addEvent"> add Event </v-btn> -->
           <v-spacer></v-spacer>
           <v-menu bottom right offset-y>
             <template v-slot:activator="{ on, attrs }">
@@ -46,9 +45,6 @@
             {{ defaultCalendarTitle }}
           </v-toolbar-title>
           <v-spacer></v-spacer>
-          <!-- <v-btn outlined class="mr-4" color="grey darken-2" @click="setToday">
-            Today
-          </v-btn> -->
           <v-menu bottom right offset-y>
             <template v-slot:activator="{ on, attrs }">
               <v-btn outlined color="grey darken-2" v-bind="attrs" v-on="on">
@@ -89,7 +85,6 @@
           @click:event="showEvent"
           @click:more="viewDay"
           @click:date="viewDay"
-          @change="updateRange"
         >
           <template v-slot:event="{ event }">
             &thinsp; {{ event.name }}
@@ -101,37 +96,26 @@
           :activator="selectedElement"
           offset-x
           offset-y
-          :min-width="width < 600 ? width * 0.7 : 600*0.7"
+          :min-width="width < 600 ? width * 0.7 : 600 * 0.7"
         >
-          <v-card color="grey lighten-4" flat>
+          <v-card color="grey lighten-4" :width="width < 600 ? width * 0.7 : 600 * 0.7" flat>
             <v-toolbar :color="selectedEvent.color" dark>
-              <!-- <v-btn icon>
-                <v-icon>mdi-pencil</v-icon>
-              </v-btn> -->
               <v-toolbar-title v-html="selectedEvent.name" />
-              <!-- <v-spacer></v-spacer>
-              <v-btn icon>
-                <v-icon>mdi-heart</v-icon>
-              </v-btn>
-              <v-btn icon>
-                <v-icon>mdi-dots-vertical</v-icon>
-              </v-btn> -->
             </v-toolbar>
-            <v-card-text>
-              <span v-html="selectedEvent.details"></span>
-              {{ width }}-{{ height }}
-            </v-card-text>
             <v-card-actions>
               <v-btn text color="secondary" @click="selectedOpen = false">
-                Cancel
+                閉じる
               </v-btn>
               <v-spacer></v-spacer>
-              <button @click="externalLink('https://www.google.com')">
+              <button @click="externalLink(selectedEvent.url)">
                 <v-btn color="orange" style="text-transform: none">
-                  Click
+                  詳細URL
                 </v-btn>
               </button>
             </v-card-actions>
+            <v-card-text>
+              <span v-html="selectedEvent.details"></span>
+            </v-card-text>
           </v-card>
         </v-menu>
       </v-sheet>
@@ -143,6 +127,10 @@
 export default {
   name: 'CalendarPage',
   data: () => ({
+    user: {},
+    username: '',
+    isLogined: false,
+    loginUserId: '', // this.$fire.auth.currentUser.uid, // ログインid
     width: window.innerWidth,
     height: window.innerHeight,
     defaultCalendarTitle: '',
@@ -198,112 +186,68 @@ export default {
     selectedOpen: false,
     allEvents: [],
     events: [],
-    colors: [
-      'red',
-      'blue',
-      'indigo',
-      'deep-purple',
-      'cyan',
-      'green',
-      'orange',
-      'grey darken-1',
-    ],
-    names: [
-      'Meeting',
-      'Holiday',
-      'PTO',
-      'Travel',
-      'Event',
-      'Birthday',
-      'Conference',
-      'Party',
-    ],
   }),
   created() {
-    this.allEvents = [
-      {
-        name: '就活イベント',
-        start: new Date(2022, 7 - 1, 1, 13, 30, 30),
-        end: new Date(2022, 7 - 1, 1, 13, 50, 30),
-        timed: true,
-        details: 'イベント詳細について <br>zcom',
-        category: '就活講座',
-      },
-      {
-        name: '就活イベント',
-        start: new Date(2022, 7 - 1, 2, 13, 30, 30),
-        end: new Date(2022, 7 - 1, 2, 13, 50, 30),
-        timed: true,
-        details: 'イベント詳細について <br>zcom',
-        category: 'キャリア設計',
-      },
-      {
-        name: '就活イベント',
-        start: new Date(2022, 7 - 1, 3, 13, 30, 30),
-        end: new Date(2022, 7 - 1, 3, 13, 50, 30),
-        timed: true,
-        details: 'イベント詳細について <br>zcom',
-        category: '合同説明会',
-      },
-      {
-        name: '就活イベント',
-        start: new Date(2022, 7 - 1, 4, 13, 30, 30),
-        end: new Date(2022, 7 - 1, 4, 13, 50, 30),
-        timed: true,
-        details: 'イベント詳細について <br>zcom',
-        category: '個社説明会・インターン',
-      },
-      {
-        name: '就活イベント',
-        start: new Date(2022, 7 - 1, 5, 13, 30, 30),
-        end: new Date(2022, 7 - 1, 5, 13, 50, 30),
-        timed: true,
-        details: 'イベント詳細について <br>zcom',
-        category: '自己分析',
-      },
-      {
-        name: '就活イベント',
-        start: new Date(2022, 7 - 1, 6, 13, 30, 30),
-        end: new Date(2022, 7 - 1, 6, 13, 50, 30),
-        timed: true,
-        details: 'イベント詳細について <br>zcom',
-        category: 'ES',
-      },
-      {
-        name: '就活イベント',
-        start: new Date(2022, 7 - 1, 7, 13, 30, 30),
-        end: new Date(2022, 7 - 1, 7, 13, 50, 30),
-        timed: true,
-        details: 'イベント詳細について <br>zcom',
-        category: 'GD',
-      },
-      {
-        name: '就活イベント',
-        start: new Date(2022, 7 - 1, 7, 13, 30, 30),
-        end: new Date(2022, 7 - 1, 7, 13, 50, 30),
-        timed: true,
-        details: 'イベント詳細について <br>zcom',
-        category: 'GD',
-      },
-      {
-        name: '就活イベント',
-        start: new Date(2022, 7 - 1, 8, 13, 30, 30),
-        end: new Date(2022, 7 - 1, 8, 13, 50, 30),
-        timed: true,
-        details: 'イベント詳細について <br>zcom',
-        category: '面接',
-      },
-    ]
-    for (const event of this.allEvents) {
-      event.color = this.category[event.category].color
-    }
-    this.events = this.allEvents
+    this.$fire.auth.onAuthStateChanged((user) => {
+      if (user) {
+        this.loginUserId = user.photoURL // encourage_idを利用！
+        this.user = user
+        this.username = user
+        this.isLogined = !!user
+        if (this.user.photoURL === 'sample') {
+          this.user.photoURL = null
+        }
+        const univ = this.$store.getters['users/univ'](this.loginUserId) // Bc={名古屋大学, 名古屋工業大学}
+        let obtainedEvents = []
+        if (univ === '名古屋大学') {
+          obtainedEvents = this.$store.getters['NUevents/all']
+        } else if (univ === '名古屋工業大学') {
+          obtainedEvents = this.$store.getters['NITevents/all']
+        }
+
+        const events = []
+        for (const e of obtainedEvents) {
+          if (!Object.prototype.hasOwnProperty.call(e, 'daytime')) continue;
+          for (const d of e.daytime) {
+            const date = d.day.split('(')
+            const yearMonthDay = date[0].split('/')
+            const startHourMinute = d.start.split(':')
+            const endHourMinute = d.end.split(':')
+            events.push({
+              name: e.ctitle,
+              start: new Date(
+                yearMonthDay[0],
+                yearMonthDay[1] - 1,
+                yearMonthDay[2],
+                startHourMinute[0],
+                startHourMinute[1]
+              ),
+              end: new Date(
+                yearMonthDay[0],
+                yearMonthDay[1] - 1,
+                yearMonthDay[2],
+                endHourMinute[0],
+                endHourMinute[1]
+              ),
+              timed: !(startHourMinute[0]===endHourMinute[0] && startHourMinute[1]===endHourMinute[1]),
+              details: e.zcom,
+              category: e.category,
+              color: this.category[e.category].color,
+              url: e.url,
+            })
+          }
+        }
+        this.allEvents = events
+        this.events = events
+      } else {
+        this.user = null
+      }
+    })
 
     const now = new Date()
     const year = now.getFullYear()
     const month = now.getMonth() + 1
     this.defaultCalendarTitle = month + '月' + ' ' + year
-    
   },
   mounted() {
     this.$refs.calendar.checkChange()
@@ -320,9 +264,6 @@ export default {
     },
     getEventColor(event) {
       return event.color
-    },
-    setToday() {
-      this.focus = ''
     },
     prev() {
       this.$refs.calendar.prev()
@@ -347,21 +288,6 @@ export default {
         open()
       }
       nativeEvent.stopPropagation()
-    },
-    updateRange({ start, end }) {},
-    rnd(a, b) {
-      return Math.floor((b - a + 1) * Math.random()) + a
-    },
-    addEvent() {
-      const events = this.events
-      events.push({
-        name: '就活講座',
-        start: new Date(2022, 7 - 1, 25, 13),
-        end: new Date(2022, 7 - 1, 25, 15),
-        color: 'red',
-        timed: true,
-      })
-      this.events = events
     },
     externalLink(url) {
       window.open(url, '_blank')

--- a/encourage/pages/calendar.vue
+++ b/encourage/pages/calendar.vue
@@ -1,17 +1,38 @@
 <template>
   <v-row class="fill-height">
     <v-col>
-      <v-btn outlined nuxt to="/">
-        <v-icon> mdi-chevron-left </v-icon>Top Page
-      </v-btn>
-      <v-btn @click="addEvent">
-        add Event
-      </v-btn>
-      <v-sheet height="64">
+      <v-sheet height="height*0.2">
         <v-toolbar flat>
-          <v-btn outlined class="mr-4" color="grey darken-2" @click="setToday">
-            Today
+          <v-btn outlined nuxt to="/">
+            <v-icon> mdi-chevron-left </v-icon>Top Page
           </v-btn>
+          <!-- <v-btn @click="addEvent"> add Event </v-btn> -->
+          <v-spacer></v-spacer>
+          <v-menu bottom right offset-y>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn outlined color="grey darken-2" v-bind="attrs" v-on="on">
+                <v-icon left :color="category[nowCategory].color">
+                  mdi-circle
+                </v-icon>
+                <span>{{ category[nowCategory].label }}</span>
+                <v-icon right> mdi-menu-down </v-icon>
+              </v-btn>
+            </template>
+            <v-list>
+              <v-list-item
+                v-for="cat in category"
+                :key="cat.label"
+                @click="viewSelectedCategory(cat.label)"
+              >
+                <v-icon left :color="cat.color"> mdi-circle </v-icon>
+                <v-list-item-title>{{ cat.label }}</v-list-item-title>
+              </v-list-item>
+            </v-list>
+          </v-menu>
+        </v-toolbar>
+      </v-sheet>
+      <v-sheet height="height*0.2">
+        <v-toolbar flat>
           <v-btn fab text small color="grey darken-2" @click="prev">
             <v-icon small> mdi-chevron-left </v-icon>
           </v-btn>
@@ -21,8 +42,14 @@
           <v-toolbar-title v-if="$refs.calendar">
             {{ $refs.calendar.title }}
           </v-toolbar-title>
+          <v-toolbar-title v-if="!$refs.calendar">
+            {{ defaultCalendarTitle }}
+          </v-toolbar-title>
           <v-spacer></v-spacer>
-          <v-menu bottom right>
+          <!-- <v-btn outlined class="mr-4" color="grey darken-2" @click="setToday">
+            Today
+          </v-btn> -->
+          <v-menu bottom right offset-y>
             <template v-slot:activator="{ on, attrs }">
               <v-btn outlined color="grey darken-2" v-bind="attrs" v-on="on">
                 <span>{{ typeToLabel[type] }}</span>
@@ -46,7 +73,7 @@
           </v-menu>
         </v-toolbar>
       </v-sheet>
-      <v-sheet height="600">
+      <v-sheet :height="height * 0.75">
         <v-calendar
           ref="calendar"
           v-model="focus"
@@ -54,38 +81,56 @@
           :events="events"
           :event-color="getEventColor"
           :type="type"
+          locale="ja-jp"
+          :day-format="(timestamp) => new Date(timestamp.date).getDate()"
+          :month-format="
+            (timestamp) => new Date(timestamp.date).getMonth() + 1 + ' /'
+          "
           @click:event="showEvent"
           @click:more="viewDay"
           @click:date="viewDay"
           @change="updateRange"
-        ></v-calendar>
+        >
+          <template v-slot:event="{ event }">
+            &thinsp; {{ event.name }}
+          </template>
+        </v-calendar>
         <v-menu
           v-model="selectedOpen"
           :close-on-content-click="false"
           :activator="selectedElement"
           offset-x
+          offset-y
+          :min-width="width < 600 ? width * 0.7 : 600*0.7"
         >
-          <v-card color="grey lighten-4" min-width="350px" flat>
+          <v-card color="grey lighten-4" flat>
             <v-toolbar :color="selectedEvent.color" dark>
-              <v-btn icon>
+              <!-- <v-btn icon>
                 <v-icon>mdi-pencil</v-icon>
-              </v-btn>
-              <v-toolbar-title v-html="selectedEvent.name"></v-toolbar-title>
-              <v-spacer></v-spacer>
+              </v-btn> -->
+              <v-toolbar-title v-html="selectedEvent.name" />
+              <!-- <v-spacer></v-spacer>
               <v-btn icon>
                 <v-icon>mdi-heart</v-icon>
               </v-btn>
               <v-btn icon>
                 <v-icon>mdi-dots-vertical</v-icon>
-              </v-btn>
+              </v-btn> -->
             </v-toolbar>
             <v-card-text>
               <span v-html="selectedEvent.details"></span>
+              {{ width }}-{{ height }}
             </v-card-text>
             <v-card-actions>
               <v-btn text color="secondary" @click="selectedOpen = false">
                 Cancel
               </v-btn>
+              <v-spacer></v-spacer>
+              <button @click="externalLink('https://www.google.com')">
+                <v-btn color="orange" style="text-transform: none">
+                  Click
+                </v-btn>
+              </button>
             </v-card-actions>
           </v-card>
         </v-menu>
@@ -98,6 +143,9 @@
 export default {
   name: 'CalendarPage',
   data: () => ({
+    width: window.innerWidth,
+    height: window.innerHeight,
+    defaultCalendarTitle: '',
     focus: '',
     type: 'month',
     typeToLabel: {
@@ -106,11 +154,52 @@ export default {
       day: 'Day',
       '4day': '4 Days',
     },
+    nowCategory: 'すべて',
+    category: {
+      すべて: {
+        label: 'すべて',
+        color: 'white',
+      },
+      就活講座: {
+        label: '就活講座',
+        color: 'red',
+      },
+      キャリア設計: {
+        label: 'キャリア設計',
+        color: 'blue',
+      },
+      合同説明会: {
+        label: '合同説明会',
+        color: 'indigo',
+      },
+      '個社説明会・インターン': {
+        label: '個社説明会・インターン',
+        color: 'deep-purple',
+      },
+      自己分析: {
+        label: '自己分析',
+        color: 'cyan',
+      },
+      ES: {
+        label: 'ES',
+        color: 'green',
+      },
+      GD: {
+        label: 'GD',
+        color: 'orange',
+      },
+      面接: {
+        label: '面接',
+        color: 'grey darken-1',
+      },
+    },
     selectedEvent: {},
     selectedElement: null,
     selectedOpen: false,
+    allEvents: [],
     events: [],
     colors: [
+      'red',
       'blue',
       'indigo',
       'deep-purple',
@@ -130,10 +219,101 @@ export default {
       'Party',
     ],
   }),
+  created() {
+    this.allEvents = [
+      {
+        name: '就活イベント',
+        start: new Date(2022, 7 - 1, 1, 13, 30, 30),
+        end: new Date(2022, 7 - 1, 1, 13, 50, 30),
+        timed: true,
+        details: 'イベント詳細について <br>zcom',
+        category: '就活講座',
+      },
+      {
+        name: '就活イベント',
+        start: new Date(2022, 7 - 1, 2, 13, 30, 30),
+        end: new Date(2022, 7 - 1, 2, 13, 50, 30),
+        timed: true,
+        details: 'イベント詳細について <br>zcom',
+        category: 'キャリア設計',
+      },
+      {
+        name: '就活イベント',
+        start: new Date(2022, 7 - 1, 3, 13, 30, 30),
+        end: new Date(2022, 7 - 1, 3, 13, 50, 30),
+        timed: true,
+        details: 'イベント詳細について <br>zcom',
+        category: '合同説明会',
+      },
+      {
+        name: '就活イベント',
+        start: new Date(2022, 7 - 1, 4, 13, 30, 30),
+        end: new Date(2022, 7 - 1, 4, 13, 50, 30),
+        timed: true,
+        details: 'イベント詳細について <br>zcom',
+        category: '個社説明会・インターン',
+      },
+      {
+        name: '就活イベント',
+        start: new Date(2022, 7 - 1, 5, 13, 30, 30),
+        end: new Date(2022, 7 - 1, 5, 13, 50, 30),
+        timed: true,
+        details: 'イベント詳細について <br>zcom',
+        category: '自己分析',
+      },
+      {
+        name: '就活イベント',
+        start: new Date(2022, 7 - 1, 6, 13, 30, 30),
+        end: new Date(2022, 7 - 1, 6, 13, 50, 30),
+        timed: true,
+        details: 'イベント詳細について <br>zcom',
+        category: 'ES',
+      },
+      {
+        name: '就活イベント',
+        start: new Date(2022, 7 - 1, 7, 13, 30, 30),
+        end: new Date(2022, 7 - 1, 7, 13, 50, 30),
+        timed: true,
+        details: 'イベント詳細について <br>zcom',
+        category: 'GD',
+      },
+      {
+        name: '就活イベント',
+        start: new Date(2022, 7 - 1, 7, 13, 30, 30),
+        end: new Date(2022, 7 - 1, 7, 13, 50, 30),
+        timed: true,
+        details: 'イベント詳細について <br>zcom',
+        category: 'GD',
+      },
+      {
+        name: '就活イベント',
+        start: new Date(2022, 7 - 1, 8, 13, 30, 30),
+        end: new Date(2022, 7 - 1, 8, 13, 50, 30),
+        timed: true,
+        details: 'イベント詳細について <br>zcom',
+        category: '面接',
+      },
+    ]
+    for (const event of this.allEvents) {
+      event.color = this.category[event.category].color
+    }
+    this.events = this.allEvents
+
+    const now = new Date()
+    const year = now.getFullYear()
+    const month = now.getMonth() + 1
+    this.defaultCalendarTitle = month + '月' + ' ' + year
+    
+  },
   mounted() {
     this.$refs.calendar.checkChange()
+    window.addEventListener('resize', this.handleResize)
   },
   methods: {
+    handleResize() {
+      this.width = window.innerWidth
+      this.height = window.innerHeight
+    },
     viewDay({ date }) {
       this.focus = date
       this.type = 'day'
@@ -168,37 +348,7 @@ export default {
       }
       nativeEvent.stopPropagation()
     },
-    updateRange({ start, end }) {
-      const events = []
-      const min = new Date(`${start.date}T00:00:00`)
-      const max = new Date(`${end.date}T23:59:59`)
-      const days = (max.getTime() - min.getTime()) / 86400000
-      const eventCount = this.rnd(days, days + 20)
-      for (let i = 0; i < eventCount; i++) {
-        const allDay = this.rnd(0, 3) === 0
-        const firstTimestamp = this.rnd(min.getTime(), max.getTime())
-        const first = new Date(firstTimestamp - (firstTimestamp % 900000))
-        const secondTimestamp = this.rnd(2, allDay ? 288 : 8) * 900000
-        const second = new Date(first.getTime() + secondTimestamp)
-        events.push({
-          name: this.names[this.rnd(0, this.names.length - 1)],
-          start: first,
-          end: second,
-          color: this.colors[this.rnd(0, this.colors.length - 1)],
-          timed: !allDay,
-        })
-      }
-      
-      events.push({
-        name: '就活講座',
-        start: new Date(2022, 6-1, 25, 13, 30, 30),
-        end: new Date(2022, 6-1, 25, 15, 50, 50),
-        color: 'blue',
-        timed: true,
-      })
-      this.events = events
-      console.log(this.events)
-    },
+    updateRange({ start, end }) {},
     rnd(a, b) {
       return Math.floor((b - a + 1) * Math.random()) + a
     },
@@ -206,13 +356,27 @@ export default {
       const events = this.events
       events.push({
         name: '就活講座',
-        start: new Date(2022, 6-1, 25, 13),
-        end: new Date(2022, 6-1, 25, 15),
+        start: new Date(2022, 7 - 1, 25, 13),
+        end: new Date(2022, 7 - 1, 25, 15),
         color: 'red',
         timed: true,
       })
       this.events = events
     },
+    externalLink(url) {
+      window.open(url, '_blank')
+    },
+    viewSelectedCategory(category) {
+      this.nowCategory = category
+      if (category === 'すべて') {
+        this.events = this.allEvents
+      } else {
+        this.events = this.allEvents.filter((e) => e.category === category)
+      }
+    },
+  },
+  beforeDestroy() {
+    window.removeEventListener('resize', this.handleResize)
   },
 }
 </script>

--- a/encourage/pages/calendar.vue
+++ b/encourage/pages/calendar.vue
@@ -1,0 +1,195 @@
+<template>
+  <v-row class="fill-height">
+    <v-col>
+      <v-btn outlined nuxt to="/">
+        <v-icon> mdi-chevron-left </v-icon>Top Page
+      </v-btn>
+      <v-sheet height="64">
+        <v-toolbar flat>
+          <v-btn outlined class="mr-4" color="grey darken-2" @click="setToday">
+            Today
+          </v-btn>
+          <v-btn fab text small color="grey darken-2" @click="prev">
+            <v-icon small> mdi-chevron-left </v-icon>
+          </v-btn>
+          <v-btn fab text small color="grey darken-2" @click="next">
+            <v-icon small> mdi-chevron-right </v-icon>
+          </v-btn>
+          <v-toolbar-title v-if="$refs.calendar">
+            {{ $refs.calendar.title }}
+          </v-toolbar-title>
+          <v-spacer></v-spacer>
+          <v-menu bottom right>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn outlined color="grey darken-2" v-bind="attrs" v-on="on">
+                <span>{{ typeToLabel[type] }}</span>
+                <v-icon right> mdi-menu-down </v-icon>
+              </v-btn>
+            </template>
+            <v-list>
+              <v-list-item @click="type = 'day'">
+                <v-list-item-title>Day</v-list-item-title>
+              </v-list-item>
+              <v-list-item @click="type = 'week'">
+                <v-list-item-title>Week</v-list-item-title>
+              </v-list-item>
+              <v-list-item @click="type = 'month'">
+                <v-list-item-title>Month</v-list-item-title>
+              </v-list-item>
+              <v-list-item @click="type = '4day'">
+                <v-list-item-title>4 days</v-list-item-title>
+              </v-list-item>
+            </v-list>
+          </v-menu>
+        </v-toolbar>
+      </v-sheet>
+      <v-sheet height="600">
+        <v-calendar
+          ref="calendar"
+          v-model="focus"
+          color="primary"
+          :events="events"
+          :event-color="getEventColor"
+          :type="type"
+          @click:event="showEvent"
+          @click:more="viewDay"
+          @click:date="viewDay"
+          @change="updateRange"
+        ></v-calendar>
+        <v-menu
+          v-model="selectedOpen"
+          :close-on-content-click="false"
+          :activator="selectedElement"
+          offset-x
+        >
+          <v-card color="grey lighten-4" min-width="350px" flat>
+            <v-toolbar :color="selectedEvent.color" dark>
+              <v-btn icon>
+                <v-icon>mdi-pencil</v-icon>
+              </v-btn>
+              <v-toolbar-title v-html="selectedEvent.name"></v-toolbar-title>
+              <v-spacer></v-spacer>
+              <v-btn icon>
+                <v-icon>mdi-heart</v-icon>
+              </v-btn>
+              <v-btn icon>
+                <v-icon>mdi-dots-vertical</v-icon>
+              </v-btn>
+            </v-toolbar>
+            <v-card-text>
+              <span v-html="selectedEvent.details"></span>
+            </v-card-text>
+            <v-card-actions>
+              <v-btn text color="secondary" @click="selectedOpen = false">
+                Cancel
+              </v-btn>
+            </v-card-actions>
+          </v-card>
+        </v-menu>
+      </v-sheet>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+export default {
+  name: 'CalendarPage',
+  data: () => ({
+    focus: '',
+    type: 'month',
+    typeToLabel: {
+      month: 'Month',
+      week: 'Week',
+      day: 'Day',
+      '4day': '4 Days',
+    },
+    selectedEvent: {},
+    selectedElement: null,
+    selectedOpen: false,
+    events: [],
+    colors: [
+      'blue',
+      'indigo',
+      'deep-purple',
+      'cyan',
+      'green',
+      'orange',
+      'grey darken-1',
+    ],
+    names: [
+      'Meeting',
+      'Holiday',
+      'PTO',
+      'Travel',
+      'Event',
+      'Birthday',
+      'Conference',
+      'Party',
+    ],
+  }),
+  mounted() {
+    this.$refs.calendar.checkChange()
+  },
+  methods: {
+    viewDay({ date }) {
+      this.focus = date
+      this.type = 'day'
+    },
+    getEventColor(event) {
+      return event.color
+    },
+    setToday() {
+      this.focus = ''
+    },
+    prev() {
+      this.$refs.calendar.prev()
+    },
+    next() {
+      this.$refs.calendar.next()
+    },
+    showEvent({ nativeEvent, event }) {
+      const open = () => {
+        this.selectedEvent = event
+        this.selectedElement = nativeEvent.target
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            this.selectedOpen = true
+          })
+        })
+      }
+      if (this.selectedOpen) {
+        this.selectedOpen = false
+        requestAnimationFrame(() => requestAnimationFrame(() => open()))
+      } else {
+        open()
+      }
+      nativeEvent.stopPropagation()
+    },
+    updateRange({ start, end }) {
+      const events = []
+      const min = new Date(`${start.date}T00:00:00`)
+      const max = new Date(`${end.date}T23:59:59`)
+      const days = (max.getTime() - min.getTime()) / 86400000
+      const eventCount = this.rnd(days, days + 20)
+      for (let i = 0; i < eventCount; i++) {
+        const allDay = this.rnd(0, 3) === 0
+        const firstTimestamp = this.rnd(min.getTime(), max.getTime())
+        const first = new Date(firstTimestamp - (firstTimestamp % 900000))
+        const secondTimestamp = this.rnd(2, allDay ? 288 : 8) * 900000
+        const second = new Date(first.getTime() + secondTimestamp)
+        events.push({
+          name: this.names[this.rnd(0, this.names.length - 1)],
+          start: first,
+          end: second,
+          color: this.colors[this.rnd(0, this.colors.length - 1)],
+          timed: !allDay,
+        })
+      }
+      this.events = events
+    },
+    rnd(a, b) {
+      return Math.floor((b - a + 1) * Math.random()) + a
+    },
+  },
+}
+</script>

--- a/encourage/pages/calendar.vue
+++ b/encourage/pages/calendar.vue
@@ -53,17 +53,12 @@
               </v-btn>
             </template>
             <v-list>
-              <v-list-item @click="type = 'day'">
-                <v-list-item-title>Day</v-list-item-title>
-              </v-list-item>
-              <v-list-item @click="type = 'week'">
-                <v-list-item-title>Week</v-list-item-title>
-              </v-list-item>
-              <v-list-item @click="type = 'month'">
-                <v-list-item-title>Month</v-list-item-title>
-              </v-list-item>
-              <v-list-item @click="type = '4day'">
-                <v-list-item-title>4 days</v-list-item-title>
+              <v-list-item
+                v-for="(value, key) in typeToLabel"
+                :key="key"
+                @click="type = key"
+              >
+                <v-list-item-title>{{ value }}</v-list-item-title>
               </v-list-item>
             </v-list>
           </v-menu>
@@ -98,7 +93,11 @@
           offset-y
           :min-width="width < 600 ? width * 0.7 : 600 * 0.7"
         >
-          <v-card color="grey lighten-4" :width="width < 600 ? width * 0.7 : 600 * 0.7" flat>
+          <v-card
+            color="grey lighten-4"
+            :width="width < 600 ? width * 0.7 : 600 * 0.7"
+            flat
+          >
             <v-toolbar :color="selectedEvent.color" dark>
               <v-toolbar-title v-html="selectedEvent.name" />
             </v-toolbar>
@@ -137,10 +136,10 @@ export default {
     focus: '',
     type: 'month',
     typeToLabel: {
-      month: 'Month',
-      week: 'Week',
-      day: 'Day',
-      '4day': '4 Days',
+      month: '月',
+      week: '週',
+      day: '日',
+      '4day': '4日',
     },
     nowCategory: 'すべて',
     category: {
@@ -207,7 +206,7 @@ export default {
 
         const events = []
         for (const e of obtainedEvents) {
-          if (!Object.prototype.hasOwnProperty.call(e, 'daytime')) continue;
+          if (!Object.prototype.hasOwnProperty.call(e, 'daytime')) continue
           for (const d of e.daytime) {
             const date = d.day.split('(')
             const yearMonthDay = date[0].split('/')
@@ -229,7 +228,10 @@ export default {
                 endHourMinute[0],
                 endHourMinute[1]
               ),
-              timed: !(startHourMinute[0]===endHourMinute[0] && startHourMinute[1]===endHourMinute[1]),
+              timed: !(
+                startHourMinute[0] === endHourMinute[0] &&
+                startHourMinute[1] === endHourMinute[1]
+              ),
               details: e.zcom,
               category: e.category,
               color: this.category[e.category].color,

--- a/encourage/pages/index.vue
+++ b/encourage/pages/index.vue
@@ -19,7 +19,7 @@
       -->
       <v-card class="mt-5 mt-8" color="red lighten-5">
         <v-card-title> 就活イベント</v-card-title>
-        <v-btn @click="viewEventCalendar">
+        <v-btn @click="viewEventCalendar" v-if="isLogined">
           イベントカレンダー <v-icon> mdi-chevron-right </v-icon>
         </v-btn>
         <v-card-text>

--- a/encourage/pages/index.vue
+++ b/encourage/pages/index.vue
@@ -20,7 +20,7 @@
       <v-card class="mt-5 mt-8" color="red lighten-5">
         <v-card-title> 就活イベント</v-card-title>
         <v-btn @click="viewEventCalendar">
-          イベントカレンダー
+          イベントカレンダー <v-icon> mdi-chevron-right </v-icon>
         </v-btn>
         <v-card-text>
           <v-container>

--- a/encourage/pages/index.vue
+++ b/encourage/pages/index.vue
@@ -19,6 +19,9 @@
       -->
       <v-card class="mt-5 mt-8" color="red lighten-5">
         <v-card-title> 就活イベント</v-card-title>
+        <v-btn @click="viewEventCalendar">
+          イベントカレンダー
+        </v-btn>
         <v-card-text>
           <v-container>
             <v-row v-for="i in 4" :key="i">
@@ -106,6 +109,9 @@ export default {
       return function () {
         this.$router.push(link)
       }
+    },
+    viewEventCalendar() {
+      this.$router.push('/calendar')
     },
   },
   computed: {

--- a/encourage/store/users.js
+++ b/encourage/store/users.js
@@ -19,7 +19,6 @@ const univList = [
 function getUserLevel(user) {
   let level = 0
   for (const key of eventKindList) {
-    console.log("User:", user);
     level += user[key].length > 0 ? 1 : 0
   }
   return level


### PR DESCRIPTION
カレンダー機能追加

- トップページに`イベントカレンダー`というボタンを追加
そのボタンからカレンダーページへ遷移可能
- 自分の所属する大学のイベントをカレンダー表示
  表示切替可能
    - 月
    - 週
    - 日
    - 4日
- イベントのカテゴリごとに表示切替可能
  8つのカテゴリとすべてのカテゴリ
- イベントをタップすれば，イベントの詳細表示
  表示方法についてはいろいろ考える必要がありそう
  開始時間と終了時間の表示など，締め切りがあるタイプなど
